### PR TITLE
[#46]fix：Intel Mac でバックエンドが CGO 無効ビルドにより起動失敗する問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,12 @@ jobs:
       - name: Build backend (macOS)
         run: |
           cd backend
-          GOOS=darwin GOARCH=arm64 go build -o dist/darwin/arm64/backnote-backend ./cmd/main.go
-          GOOS=darwin GOARCH=amd64 go build -o dist/darwin/x64/backnote-backend ./cmd/main.go
+          CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 \
+            CC="clang -arch arm64" CXX="clang++ -arch arm64" \
+            go build -o dist/darwin/arm64/backnote-backend ./cmd/main.go
+          CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 \
+            CC="clang -arch x86_64" CXX="clang++ -arch x86_64" \
+            go build -o dist/darwin/x64/backnote-backend ./cmd/main.go
 
       - name: Build frontend
         run: npm run build

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -7,11 +7,15 @@ echo "Building Backnote backend..."
 
 # macOS arm64
 echo "  → darwin/arm64"
-GOOS=darwin GOARCH=arm64 go build -o dist/darwin/arm64/backnote-backend ./cmd/main.go
+CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 \
+  CC="clang -arch arm64" CXX="clang++ -arch arm64" \
+  go build -o dist/darwin/arm64/backnote-backend ./cmd/main.go
 
 # macOS x64
 echo "  → darwin/amd64"
-GOOS=darwin GOARCH=amd64 go build -o dist/darwin/x64/backnote-backend ./cmd/main.go
+CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 \
+  CC="clang -arch x86_64" CXX="clang++ -arch x86_64" \
+  go build -o dist/darwin/x64/backnote-backend ./cmd/main.go
 
 # Windows x64
 echo "  → windows/amd64"


### PR DESCRIPTION
## 変更の概要

Intel Mac で Backnote.app を開いた直後に「処理が予期せず終了しました」「起動に失敗しました」のアラートが連続表示され、その後ウィンドウは開くものの API へ繋がらない事象を修正する。

原因は darwin/amd64 向けバックエンドが `CGO_ENABLED=0` でビルドされていたこと。Apple Silicon マシン上で `GOOS=darwin GOARCH=amd64 go build` を走らせると Go がクロスコンパイル扱いで CGO を無効化するため、`mattn/go-sqlite3` が stub になり、起動直後に `go-sqlite3 requires cgo to work` で死亡していた。

## 関連 Issue

- closes #46
- 関連: #47 (Windows/Linux も同様に CGO_ENABLED=1 を明示する追跡)

## 変更の種類

- [x] バグ修正（fix）

## 変更内容の詳細

- `scripts/build-backend.sh` の darwin/arm64・darwin/amd64 ビルドで `CGO_ENABLED=1` と `CC` / `CXX` のアーキ指定を明示
- `.github/workflows/release.yml` の `release-mac` ジョブも同じ修正を反映 (CI はベタ書きで `build-backend.sh` を呼んでいないため両方直す必要があった)
- Windows / Linux 側は本 PR スコープ外として #47 に分離

## 動作確認

- [x] ローカルで動作確認済み
- [x] 既存の機能に影響がないことを確認済み
- [ ] テストを追加・更新済み（該当する場合） ← ビルドスクリプトのため対象外

### 検証ログ

修正後の x64 バイナリを Apple Silicon マシン (Rosetta) 上で実行:

\`\`\`
=== curl /api/health ===
HTTP/1.1 200 OK
{"status":"ok"}

=== log ===
dbwriter: started
Backnote backend starting on :18082
⇨ http server started on [::]:18082
GET /api/health status=200
\`\`\`

`otool -L` の libSystem current version も `0.0.0` (stub) → `1351.0.0` (CGO=1) に変化していることを確認。

## レビュアーへのメモ

- マージ後は配布物 (v1.1.1 dmg) が修正前のままなので、**v1.1.2 タグを打って再配布が必要**
- arm64 側は元々ネイティブビルドで CGO=1 だったが、クロス設定を統一する意図で同じ書式を適用 (実質的な挙動変化はなし)

## チェックリスト

- [x] セルフレビュー済み (code-reviewer エージェントの Critical 指摘も反映)
- [x] コード規約に沿っている
- [x] デバッグ用の出力（console.log等）を削除済み
- [x] ハードコードされた認証情報・APIキーがない