### PR TITLE
[#49]chore：バックエンド健全性調査のためのログ仕込みと exit/health 監視を追加

### DIFF
--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, spawn } from 'child_process'
-import { app, dialog } from 'electron'
+import { app, dialog, Notification } from 'electron'
 import { join } from 'path'
-import { existsSync } from 'fs'
+import { existsSync, mkdirSync, createWriteStream, WriteStream } from 'fs'
 import * as http from 'http'
 
 const MAX_HEALTH_CHECK_RETRIES = 30
@@ -9,9 +9,35 @@ const HEALTH_CHECK_INTERVAL_MS = 500
 const HEALTH_CHECK_TIMEOUT_MS = 1000
 const GRACEFUL_SHUTDOWN_MS = 3000
 
+// 起動後の生存監視 (#49 調査用)
+const HEALTH_WATCH_INTERVAL_MS = 30 * 1000
+const HEALTH_WATCH_TIMEOUT_MS = 5 * 1000
+const HEALTH_WATCH_FAIL_THRESHOLD = 3
+
 export const BACKEND_PORT = 8080
 
 let backendProcess: ChildProcess | null = null
+let logStream: WriteStream | null = null
+let healthWatcherTimer: NodeJS.Timeout | null = null
+let consecutiveHealthFailures = 0
+let healthNotifiedAt: number | null = null
+
+function getLogStream(): WriteStream {
+  if (logStream) return logStream
+  const dir = app.getPath('logs')
+  mkdirSync(dir, { recursive: true })
+  const path = join(dir, 'backend.log')
+  // バックエンドの Echo middleware は method/uri/status/latency のみ出力する設定 (backend/cmd/main.go)
+  // であり Authorization ヘッダや API トークンを stdout に書き出さないため、生 pipe で問題ない。
+  // TODO(#49): 調査完了後にローテーション or 期間トリムを検討する。
+  logStream = createWriteStream(path, { flags: 'a' })
+  return logStream
+}
+
+function logEvent(line: string): void {
+  const stream = getLogStream()
+  stream.write(`[${new Date().toISOString()}] [main] ${line}\n`)
+}
 
 function getBackendPath(): string {
   if (app.isPackaged) {
@@ -26,6 +52,8 @@ function waitForHealth(port: number): Promise<void> {
 
     const check = (): void => {
       const req = http.get(`http://localhost:${port}/api/health`, (res) => {
+        // body を消費して Keep-Alive socket を解放する (連続リトライ時の遅延防止)
+        res.resume()
         if (res.statusCode === 200) {
           resolve()
         } else {
@@ -56,10 +84,65 @@ function waitForHealth(port: number): Promise<void> {
   })
 }
 
+function startHealthWatcher(port: number): void {
+  if (healthWatcherTimer) clearInterval(healthWatcherTimer)
+  consecutiveHealthFailures = 0
+  healthNotifiedAt = null
+
+  const onSuccess = (): void => {
+    if (consecutiveHealthFailures > 0) {
+      logEvent(`health recovered after ${consecutiveHealthFailures} failure(s)`)
+    }
+    consecutiveHealthFailures = 0
+    healthNotifiedAt = null
+  }
+
+  const onFailure = (reason: string): void => {
+    consecutiveHealthFailures++
+    logEvent(`health watch failed (${consecutiveHealthFailures}): ${reason}`)
+
+    if (
+      consecutiveHealthFailures >= HEALTH_WATCH_FAIL_THRESHOLD &&
+      healthNotifiedAt === null
+    ) {
+      healthNotifiedAt = Date.now()
+      logEvent(`health watch: threshold reached, surfacing notification`)
+      try {
+        new Notification({
+          title: 'Backnote バックエンド応答なし',
+          body: `${HEALTH_WATCH_FAIL_THRESHOLD} 回連続で /api/health に失敗しました。ログを確認してください。`
+        }).show()
+      } catch (e) {
+        logEvent(`notification failed: ${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+  }
+
+  healthWatcherTimer = setInterval(() => {
+    const req = http.get(`http://localhost:${port}/api/health`, (res) => {
+      // body を消費して Keep-Alive socket を解放する
+      res.resume()
+      if (res.statusCode === 200) {
+        onSuccess()
+      } else {
+        onFailure(`status=${res.statusCode}`)
+      }
+    })
+    req.on('error', (err) => onFailure(`error=${err.message}`))
+    req.setTimeout(HEALTH_WATCH_TIMEOUT_MS, () => {
+      req.destroy()
+      onFailure('timeout')
+    })
+  }, HEALTH_WATCH_INTERVAL_MS)
+}
+
 export async function startBackend(port: number = BACKEND_PORT): Promise<void> {
   const backendPath = getBackendPath()
+  const stream = getLogStream()
+  stream.write(`\n===== ${new Date().toISOString()} startBackend port=${port} =====\n`)
 
   if (!existsSync(backendPath)) {
+    logEvent(`ERROR: backend binary not found: ${backendPath}`)
     throw new Error(`Backend binary not found: ${backendPath}`)
   }
 
@@ -72,26 +155,61 @@ export async function startBackend(port: number = BACKEND_PORT): Promise<void> {
       stdio: ['ignore', 'pipe', 'pipe']
     })
 
+    logEvent(`backend spawned pid=${backendProcess.pid} path=${backendPath}`)
+
+    backendProcess.stdout?.pipe(stream, { end: false })
+    backendProcess.stderr?.pipe(stream, { end: false })
+
     backendProcess.on('error', (err) => {
+      logEvent(`backend spawn error: ${err.message}`)
       backendProcess = null
       reject(new Error(`Backend spawn failed: ${err.message}`))
     })
 
-    backendProcess.on('exit', (code) => {
+    backendProcess.on('exit', (code, signal) => {
+      const detail = code !== null ? `code=${code}` : `signal=${signal}`
+      logEvent(`backend exited ${detail}`)
       backendProcess = null
-      if (code !== 0 && code !== null) {
+
+      if (healthWatcherTimer) {
+        clearInterval(healthWatcherTimer)
+        healthWatcherTimer = null
+      }
+
+      // 異常終了 (非 0 終了 or シグナル終了) は通知。
+      // SIGTERM はアプリ終了時の正規シャットダウンなので除外。
+      const abnormal = (code !== null && code !== 0) || (signal !== null && signal !== 'SIGTERM')
+      if (abnormal) {
         dialog.showErrorBox(
           'Backnote エラー',
-          `処理が予期せず終了しました。アプリを再起動してください。\n(error code: ${code})`
+          `処理が予期せず終了しました。アプリを再起動してください。\n(${detail})`
         )
       }
     })
 
-    waitForHealth(port).then(resolve).catch(reject)
+    waitForHealth(port)
+      .then(() => {
+        logEvent('backend health OK, starting watcher')
+        startHealthWatcher(port)
+        resolve()
+      })
+      .catch((err) => {
+        logEvent(`backend startup health timeout: ${err.message}`)
+        reject(err)
+      })
   })
 }
 
 export function stopBackend(): void {
+  if (healthWatcherTimer) {
+    clearInterval(healthWatcherTimer)
+    healthWatcherTimer = null
+  }
+
+  if (logStream) {
+    logStream.write(`===== ${new Date().toISOString()} stopBackend =====\n`)
+  }
+
   if (!backendProcess) return
 
   const proc = backendProcess


### PR DESCRIPTION
## 変更の概要

長時間稼働後にバックエンドが応答しなくなり「更新ボタンを押してもローディングが終わらない」事象 (#49) の**原因切り分け用の観測強化**。根本修正ではなく、再現を待ってログから仮説を絞り込めるようにする。

## 関連 Issue

- #49 (本 PR で観測手段を追加。根本修正は別 PR)

## 変更の種類

- [x] その他（chore） - 調査用ログ・監視の追加

## 変更内容の詳細

[src/main/backend.ts](src/main/backend.ts) のみ。

1. **stdout/stderr 永続化**: 子プロセスの stdout/stderr を `app.getPath('logs')/backend.log` に追記モードで pipe
2. **主要イベントのログ化**: spawn / exit / health 成功・失敗・復旧などをログに記録
3. **exit ハンドラ拡張**: `(code, signal)` で受け、シグナル終了 (SIGTERM 以外) も「処理が予期せず終了しました」アラートの対象に含める。OOM kill / クラッシュも検知できるように
4. **health watcher**: 起動完了後に 30 秒間隔で `/api/health` を ping。3 回連続失敗で OS 通知を 1 度だけ表示。復旧したら状態リセット
5. **res.resume()**: 連続 health check で Keep-Alive socket が滞留しないよう response body を消費

### 安全性チェック

- バックエンドの Echo middleware は `method/uri/status/latency` のみ出力する設定 ([backend/cmd/main.go:51-53](backend/cmd/main.go#L51-L53))。Authorization ヘッダや API トークンは stdout に乗らないことを確認済み

## 動作確認

- [x] ローカルで動作確認済み (型チェック通過、`npm run dev` 起動・停止サイクル正常)
- [x] 既存の機能に影響がないことを確認済み
- [ ] テストを追加・更新済み（該当する場合） ← 観測用フックのため対象外

## レビュアーへのメモ

- ログのローテーション・サイズトリムは未実装。コード内に `TODO(#49)` を残してある。調査完了後に削除 or ローテーション機構の追加を判断
- 通知は throttle 済み (`healthNotifiedAt` で 1 回に絞り、復旧でリセット)
- マージ後、ローカルで `npm run dev` を起動したまま長時間放置し、再現を待ってログを `~/Library/Logs/Backnote/backend.log` から確認する想定

## チェックリスト

- [x] セルフレビュー済み (code-reviewer エージェントの Suggestion 3 件を反映)
- [x] コード規約に沿っている
- [x] デバッグ用の出力（console.log等）を削除済み
- [x] ハードコードされた認証情報・APIキーがない